### PR TITLE
Update ControllerProxyCRUD.java

### DIFF
--- a/project-code/app/play/utils/crud/ControllerProxyCRUD.java
+++ b/project-code/app/play/utils/crud/ControllerProxyCRUD.java
@@ -17,7 +17,7 @@ public class ControllerProxyCRUD<K, M> extends ControllerProxy<K, M> {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Result editForm(String key) {
 		K k = keyConverter.convert(key);
-		return ((CRUDController)delegate).editForm(key);
+		return ((CRUDController)delegate).editForm(k);
 	}
 
 }


### PR DESCRIPTION
Fix for the [IllegalArgumentException: argument type mismatch] exception that occurs when we use a static form template.

Steps to reproduce:
1. run the play2-crud-customView
2. create a Simple object [localhost:9000/app/Simple/new]
3. Try to edit this object [localhost:9000/app/Simple/1/edit]
