### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can begin with adding play2-crud dependency inside `conf/Build.scala` file.
 ```
 
 ### Associate Global settings
-####Direct reference
+#### Direct reference
 If you don't want to override the play application launcher, you just have to notice to play that the class to use as launcher is now GlobalCRUDSettings. Change the `application.global` configuration key in the `conf/application.conf` file, and use `play.utils.crud.GlobalCRUDSettings`:
 
 ```

--- a/docs/custom-controller.md
+++ b/docs/custom-controller.md
@@ -44,7 +44,7 @@ public class SampleController extends CRUDController<Long, Sample> {
 ```
 [Definition of the class SampleDAO is here.](custom-dao.md)
 
-###Overriding controller actions
+### Overriding controller actions
 Since the actions of the CrudController are not static, you can override them and use generic types !
 
 List of the functions you can override :

--- a/docs/custom-dao.md
+++ b/docs/custom-dao.md
@@ -1,9 +1,9 @@
 
 ## HOW-TO Define Custom DAO
 
-###Definition
+### Definition
 DAO stands for Data Access Object. This object is call for the interaction with the database. It overrides the create, update and delete functions.
-###Creation
+### Creation
 DAO class extends `play.utils.dao.BasicDAO` with two type parameters: One for the key type and one for the Model type and overrides the super class constructor with `super(Long.class, Sample.class)`
 Example:
 ```java
@@ -16,7 +16,7 @@ public class SampleDAO extends BasicDAO<Long, Sample> {
 Here the `SampleDAO` extends `BasicDAO<Long, Sample>` with `Long` key type, and `Sample` model type.
 
 Note that a `@Inject` (javax.inject.Inject) annotation may be required before the constructor definition.
-###Overriding DAO functions
+### Overriding DAO functions
 The interest of having DAO objects is that you can override their functions. This is the functions of the DAO that can be overrided :
 ```java
 public interface DAO<K, M> {
@@ -59,6 +59,6 @@ public class SampleDAO extends BasicDAO<Long, Sample> {
 }
 
 ```
-###DAO for cached data
+### DAO for cached data
 Alternatively, `play.utils.dao.CachedDAO` can be used to cache fetched data.
 Classes implementing both `BasicDAO` or `CachedDAO` should override the constructor with key ad model class type parameters.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
